### PR TITLE
Fixed plugin to work in kicad 7

### DIFF
--- a/kicad_spiral_plugin.py
+++ b/kicad_spiral_plugin.py
@@ -64,9 +64,9 @@ class MyPanel(MyPanel12):
         layers = []
         i = pcbnew.PCBNEW_LAYER_ID_START
         while i < pcbnew.PCBNEW_LAYER_ID_START + pcbnew.GetBoard().GetCopperLayerCount() - 1:
-            layers.append(pcbnew.BOARD_GetStandardLayerName(i))
+            layers.append(pcbnew.BOARD.GetStandardLayerName(i))
             i += 1
-        layers.append(pcbnew.BOARD_GetStandardLayerName(pcbnew.PCBNEW_LAYER_ID_START + 31))
+        layers.append(pcbnew.BOARD.GetStandardLayerName(pcbnew.PCBNEW_LAYER_ID_START + 31))
         for ii in range(len(layers)):
             self.m_choice31.Append(str(layers[ii]))
         if pcbnew.GetUserUnits() == pcbnew.EDA_UNITS_INCHES:


### PR DESCRIPTION
Closes #2.

Not sure how it was implemented in kicad 6, but now the pcbnew.BOARD is a class with GetStandardLayerName method.